### PR TITLE
Support as Firefox extension CommonJS module.

### DIFF
--- a/punycode.js
+++ b/punycode.js
@@ -525,6 +525,9 @@
 				punycode.hasOwnProperty(key) && (freeExports[key] = punycode[key]);
 			}
 		}
+	} else if (freeExports) {
+		// Firefox extension CommonJS module
+		freeExports = punycode;
 	} else {
 		// in Rhino or a web browser
 		root.punycode = punycode;


### PR DESCRIPTION
punycode.js can be used as a CommonJS reusable module in Firefox extension projects.

https://developer.mozilla.org/en-US/Add-ons/SDK/Guides/Module_structure_of_the_SDK