### PR TITLE
Update documentation to drop domain / email note

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ punycode.toUnicode('джумла@xn--p-8sbkgc5ag7bhce.xn--ba-lmcq');
 
 ### `punycode.toASCII(input)`
 
-Converts a lowercased Unicode string representing a domain name or an email address to Punycode. Only the non-ASCII parts of the input will be converted, i.e. it doesn’t matter if you call it with a domain that’s already in ASCII.
+Converts a lowercased Unicode string to Punycode. Only the non-ASCII parts of the input will be converted, i.e. it doesn’t matter if you call it with a domain that’s already in ASCII.
 
 ```js
 // encode domain names


### PR DESCRIPTION
With this note it makes it seem like it is **only** for email and web addresses when in reality it will simply leave current ascii chars alone which is useful for more domains than just email and web addresses.