### PR TITLE
jspm Node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,12 @@
 		"qunit-extras": "^1.4.1",
 		"qunitjs": "~1.11.0",
 		"requirejs": "^2.1.15"
+	},
+	"jspm": {
+		"map": {
+			"./punycode.js": {
+				"node": "@node/punycode"
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR includes the necessary jspm configuration for this package to work in Node with the coming jspm 0.17 release, allowing this single package to provide both client and server support.

I completely understand if you'd rather not support this here, but it will simplify user configuration locally having it in one place. There is no maintenance burden either as I would continue to maintain this personally.

Just let me know if you have any questions at all, and thanks for considering.