### PR TITLE
Have travis cache the npm cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
   - 6
+cache:
+  directories:
+    - $HOME/.npm
 after_script:
   - 'istanbul cover --report html node_modules/.bin/_mocha tests -- -u exports -R spec && codecov'


### PR DESCRIPTION
This will use travis' cache to preserve the npm cache so that if the registry has hiccups your testing will have a chance to keep on trucking.