### PR TITLE
Add ES6 module output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Generated files
+punycode.es6.js
+
 # Coverage report
 coverage
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This JavaScript library is the result of comparing, optimizing and documenting d
 
 This project was [bundled](https://github.com/joyent/node/blob/master/lib/punycode.js) with Node.js from [v0.6.2+](https://github.com/joyent/node/compare/975f1930b1...61e796decc) until [v7](https://github.com/nodejs/node/pull/7941) (soft-deprecated).
 
-The current version supports recent versions of Node.js only. For the old version that offers the same functionality with broader support, including Rhino, Ringo, Narwhal, and web browsers, see [v1.4.1](https://github.com/bestiejs/punycode.js/releases/tag/v1.4.1).
+The current version supports recent versions of Node.js only. It provides a CommonJS module and an ES6 module. For the old version that offers the same functionality with broader support, including Rhino, Ringo, Narwhal, and web browsers, see [v1.4.1](https://github.com/bestiejs/punycode.js/releases/tag/v1.4.1).
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A robust Punycode converter that fully complies to RFC 3492 and RFC 5891, and works on nearly all JavaScript platforms.",
   "homepage": "https://mths.be/punycode",
   "main": "punycode.js",
+  "jsnext:main": "punycode.es6.js",
   "engines": {
     "node": ">=6"
   },
@@ -34,10 +35,12 @@
   "bugs": "https://github.com/bestiejs/punycode.js/issues",
   "files": [
     "LICENSE-MIT.txt",
-    "punycode.js"
+    "punycode.js",
+    "punycode.es6.js"
   ],
   "scripts": {
-    "test": "mocha tests"
+    "test": "mocha tests",
+    "prepublish": "node ./scripts/prepublish.js"
   },
   "devDependencies": {
     "codecov": "^1.0.1",

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const regex = /module\.exports = punycode;/;
+
+const sourceContents = fs.readFileSync(path.resolve(__dirname, '../punycode.js'), 'utf-8');
+
+if (!regex.test(sourceContents)) {
+	throw new Error('The underlying library has changed. Please update the prepublish script.');
+}
+
+const outputContents = sourceContents.replace(regex, 'export default punycode;');
+
+fs.writeFileSync(path.resolve(__dirname, '../punycode.es6.js'), outputContents);


### PR DESCRIPTION
PR for #55.

Adds in a `prepublish` script (which fails to publish if the underlying code has changed) and related pieces.

Let me know if you'd like this to look any different.