### PR TITLE
Fix homepage link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "punycode",
   "version": "2.1.0",
   "description": "A robust Punycode converter that fully complies to RFC 3492 and RFC 5891, and works on nearly all JavaScript platforms.",
-  "homepage": "https://mths.be/punycode",
+  "homepage": "https://github.com/bestiejs/punycode.js",
   "main": "punycode.js",
   "jsnext:main": "punycode.es6.js",
   "engines": {


### PR DESCRIPTION
The previous link `https://mths.be/punycode` is no longer a webpage but a redirect to this repository.