### PR TITLE
Optional registration against node.js 'module'

### DIFF
--- a/punycode.js
+++ b/punycode.js
@@ -437,4 +437,9 @@ const punycode = {
 	'toUnicode': toUnicode
 };
 
-module.exports = punycode;
+/* Register with node.js when available */
+if (typeof module !== 'undefined')
+{
+	module.exports = punycode;
+}
+


### PR DESCRIPTION
This allows using punycode.js directly without node.js