### PR TITLE
Named Exports

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const regex = /module\.exports = punycode;/;
+const output = 'export { ucs2decode, ucs2encode, decode, encode, toASCII, toUnicode };\nexport default punycode;';
 
 const sourceContents = fs.readFileSync(path.resolve(__dirname, '../punycode.js'), 'utf-8');
 
@@ -11,6 +12,6 @@ if (!regex.test(sourceContents)) {
 	throw new Error('The underlying library has changed. Please update the prepublish script.');
 }
 
-const outputContents = sourceContents.replace(regex, 'export default punycode;');
+const outputContents = sourceContents.replace(regex, output);
 
 fs.writeFileSync(path.resolve(__dirname, '../punycode.es6.js'), outputContents);


### PR DESCRIPTION
This PR adds support for named exports to `punycode.es6.js`. This will allow developers to only import the functions they need, and will allow tree-shaking bundlers to better pair the code down to only what is needed.