### PR TITLE
Package Module Property

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://mths.be/punycode",
   "main": "punycode.js",
   "jsnext:main": "punycode.es6.js",
+  "module": "punycode.es6.js",
   "engines": {
     "node": ">=6"
   },


### PR DESCRIPTION
This PR adds support for the `module` property in the `package.json` file. This property is the [new way of defining ES6 modules within a package](https://github.com/rollup/rollup/wiki/pkg.module), as [`jsnext:main` is being deprecated](https://github.com/rollup/rollup/wiki/jsnext:main). I left the existing `jsnext:main` property in for backwards compatibility.