### PR TITLE
Replace "for of" loops with simple for loop to remove polyfill requirement 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Generated files
 punycode.es6.js
+package-lock.json
 
 # Coverage report
 coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "punycode",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A robust Punycode converter that fully complies to RFC 3492 and RFC 5891, and works on nearly all JavaScript platforms.",
   "homepage": "https://mths.be/punycode",
   "main": "punycode.js",

--- a/punycode.js
+++ b/punycode.js
@@ -299,7 +299,8 @@ const encode = function(input) {
 	let bias = initialBias;
 
 	// Handle the basic code points.
-	for (const currentValue of input) {
+	for (let i = 0; i < input.length; i++) {
+		const currentValue = input[i];
 		if (currentValue < 0x80) {
 			output.push(stringFromCharCode(currentValue));
 		}
@@ -322,7 +323,8 @@ const encode = function(input) {
 		// All non-basic code points < n have been handled already. Find the next
 		// larger one:
 		let m = maxInt;
-		for (const currentValue of input) {
+		for (let i = 0; i < input.length; i++) {
+			const currentValue = input[i];
 			if (currentValue >= n && currentValue < m) {
 				m = currentValue;
 			}
@@ -338,7 +340,8 @@ const encode = function(input) {
 		delta += (m - n) * handledCPCountPlusOne;
 		n = m;
 
-		for (const currentValue of input) {
+		for (let i = 0; i < input.length; i++) {
+			const currentValue = input[i];
 			if (currentValue < n && ++delta > maxInt) {
 				error('overflow');
 			}


### PR DESCRIPTION
Hey, just wanted to say I love this lib. It's lightweight and efficient.

We are using it in [twitter-text](https://github.com/twitter/twitter-text/blob/master/js/src/lib/idna.js#L19) for url validation.

There are a few usages of "for of" loop in the implementation, that is slightly problematic for legacy browsers. This is transpiled down to a variant that uses ["Symbol.Iterator" by babel](https://babeljs.io/docs/plugins/transform-es2015-for-of/). Unfortunately "Symbol" is also not supported by IE11 and needs to polyfilled.

I noticed that all the usages iterate over an array and could be replaced by a for loop. I understand that this is not the responsibility of punycode, but I think it'd be pretty useful if we remove a polyfill dependency for legacy browsers.

Also added the package-lock that comes with npm5 to the gitignore.