### PR TITLE
Ensure string is a string

### DIFF
--- a/punycode.js
+++ b/punycode.js
@@ -70,6 +70,7 @@ function map(array, fn) {
  * function.
  */
 function mapDomain(string, fn) {
+	string = String(string || '');
 	const parts = string.split('@');
 	let result = '';
 	if (parts.length > 1) {


### PR DESCRIPTION
Caught an error in my code, `TypeError: Cannot read property 'split' of undefined at mapDomain (punycode.js:73:23)`.  Figured could be prevented or if you rather, throw a better type related error.