### PR TITLE
Add test for xn--grne-milk-r9a.de

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -212,6 +212,11 @@ const testData = {
 			'description': 'Email address',
 			'decoded': '\u0434\u0436\u0443\u043C\u043B\u0430@\u0434\u0436p\u0443\u043C\u043B\u0430\u0442\u0435\u0441\u0442.b\u0440\u0444a',
 			'encoded': '\u0434\u0436\u0443\u043C\u043B\u0430@xn--p-8sbkgc5ag7bhce.xn--ba-lmcq'
+		},
+		{
+			'description': 'Domain containing LATIN SMALL LETTER U WITH DIAERESIS',
+			'decoded': 'gr\u00FCne-milk.de',
+			'encoded': 'xn--grne-milk-r9a.de'
 		}
 	],
 	'separators': [


### PR DESCRIPTION
This ensures that decoding xn--grne-milk-r9a.de to unicode works as expected.