### PR TITLE
Fix usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ npm install punycode --save
 
 In [Node.js](https://nodejs.org/):
 
+> ⚠️ Note that userland modules don't hide core modules.
+> For example, `require('punycode')` still imports the deprecated core module even if you executed `npm install punycode`.
+> Use `require('punycode/')` to import userland modules rather than core modules.
+
 ```js
-const punycode = require('punycode');
+const punycode = require('punycode/');
 ```
 
 ## API


### PR DESCRIPTION
Refs #79

This change updates the usage instructions in the README to explain the workaround required to use this module. As userland modules do not hide core modules, a trailing slash is required to have Node.js use this module over the built-in.

I copied the warning text from [the `node/no-deprecated-api` docs](https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-deprecated-api.md).

**Note:** I personally think this is confusing, but since this is the preferred workaround ([per this comment](https://github.com/bestiejs/punycode.js/issues/79#issuecomment-374518635)) and this module is what the official Node.js docs recommend,<sup>[\[1\]][1]</sup> it is worth clarifying.

  [1]:https://nodejs.org/dist/latest-v12.x/docs/api/punycode.html#punycode_punycode